### PR TITLE
Update Dapr Runtime version to 1.15.4

### DIFF
--- a/dapr-101/2-dapr-cli/assignment.md
+++ b/dapr-101/2-dapr-cli/assignment.md
@@ -80,7 +80,7 @@ The expected output should be:
 
 ```output
 CLI version: 1.15.0
-Runtime version: 1.15.0
+Runtime version: 1.15.4
 ```
 
 ## 5. Verify the containers


### PR DESCRIPTION
When running the demo, the current Runtime Version is 1.15.4